### PR TITLE
Changed "apt-get install sbt" -> "dpkg -i sbt-0.13.7.deb" to force sp…

### DIFF
--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -5,12 +5,15 @@ MAINTAINER Viktor Farcic "viktor@farcic.com"
 # Packages
 RUN echo "deb http://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
 RUN apt-get update && \
-    apt-get -y --force-yes install --no-install-recommends openjdk-7-jdk mongodb wget sbt && \
+    apt-get -y --force-yes install --no-install-recommends openjdk-7-jdk mongodb wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -q http://downloads.typesafe.com/scala/2.11.5/scala-2.11.5.deb && \
     dpkg -i scala-2.11.5.deb && \
     rm scala-2.11.5.deb
+RUN wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.7.deb && \
+    dpkg -i sbt-0.13.7.deb && \
+    rm sbt-0.13.7.deb
 
 RUN mkdir -p /data/db
 ENV TEST_TYPE "spec"


### PR DESCRIPTION
…ecific Scala version that is compatible with libraries specified in build.sbt

See longer explanation at https://technologyconversations.com/2015/02/11/continuous-integration-delivery-or-deployment-with-jenkins-docker-and-ansible/comment-page-1/#comment-12095